### PR TITLE
README: fix rST syntax errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,7 @@ Usage
 See sample/sample.py
 
 ::
+
     mc = MantisSoapConnector("url")
     mc.set_user_passwd("username", "password")
     mc.connect()
@@ -28,6 +29,7 @@ Requirement
  - zeep
 
 ::
+
     $ pip3 install mantisconnect
 
 


### PR DESCRIPTION
The double colons as colons rather than indicating the start of a preformatted text block.